### PR TITLE
fix(usb_ctrl): Use parent path

### DIFF
--- a/src/inet_nm/cli_fake_usb.py
+++ b/src/inet_nm/cli_fake_usb.py
@@ -59,7 +59,6 @@ def add_board(id=None, **kwargs):
                 "subsystem": "usb",
                 "DEVTYPE": "usb_device",
             },
-            "ID_PATH": ID_PATH,
         },
         {
             "subsystem": "tty",
@@ -73,8 +72,8 @@ def add_board(id=None, **kwargs):
                 "ID_MODEL_FROM_DATABASE": "USB Serial",
                 "ID_VENDOR_FROM_DATABASE": "QinHeng Electronics",
                 "DRIVER": "ch341",
+                "ID_PATH": ID_PATH,
             },
-            "ID_PATH": ID_PATH,
         },
     ]
     fake_devices[id] = dev

--- a/src/inet_nm/usb_ctrl.py
+++ b/src/inet_nm/usb_ctrl.py
@@ -46,7 +46,7 @@ def get_connected_id_paths() -> List[str]:
         parent = device.find_parent("usb", "usb_device")
         if parent is None:
             continue
-        locations.append(device.get("ID_PATH"))
+        locations.append(parent.get("ID_PATH"))
     return locations
 
 
@@ -74,7 +74,7 @@ def get_id_path_from_node(node: NmNode) -> str:
             and parent.get("ID_MODEL_ID") == model_id
             and parent.get("ID_SERIAL_SHORT") == serial_short
         ):
-            return device.get("ID_PATH")
+            return parent.get("ID_PATH")
     raise Exception("Node not found, maybe not connected")
 
 


### PR DESCRIPTION
Using the device path for the location results in issues, especially when having multiple ttys or endpoints.  We actually just want the location of the hub slot (ie. parent) not the location of the tty endpoint.